### PR TITLE
Epic 2: Complete homepage experience (Stories 2.3-2.6)

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,0 +1,7 @@
+// .claude/skills/debug/SKILL.md
+# Debug Workflow
+1. Ask user to describe the EXACT symptom (what they see vs what they expect)
+2. Reproduce the issue by reading relevant code and running the app
+3. State your hypothesis and ask user to confirm before implementing any fix
+4. Implement fix, run tests, verify build
+5. Update any relevant tracking docs

--- a/_bmad-output/implementation-artifacts/spec-2-1-herochapter-component.md
+++ b/_bmad-output/implementation-artifacts/spec-2-1-herochapter-component.md
@@ -1,0 +1,98 @@
+---
+title: 'HeroChapter Component'
+type: 'feature'
+created: '2026-04-05'
+status: 'done'
+baseline_commit: '632e664'
+context:
+  - '_bmad-output/planning-artifacts/ux-design-specification.md'
+  - '_bmad-output/planning-artifacts/architecture.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** The homepage is a placeholder `<h1>Home</h1>`. Visitors need a compelling first-viewport experience that immediately communicates Mike's value proposition and sets the editorial tone.
+
+**Approach:** Create a `HeroChapter.astro` component — full-viewport hero with fluid headline (key phrase in amber), subtitle, and scroll hint. Staggered CSS-only load animation behind `prefers-reduced-motion`. Wire it into the homepage.
+
+## Boundaries & Constraints
+
+**Always:**
+- Use Tailwind utility classes only (no `@apply`)
+- Use theme tokens for all colors — no raw hex
+- Animations must be CSS-only (keyframes + animation-delay), no JS animation libraries
+- All animated content must be immediately visible when `prefers-reduced-motion: reduce` is active
+- Hero must render fully without JavaScript (progressive enhancement)
+
+**Ask First:**
+- Headline copy changes beyond the UX spec wording
+- Adding any interactive elements to the hero
+
+**Never:**
+- JavaScript-driven animations for the hero reveal
+- Raw `<img>` tags
+- Horizontal scrolling on any viewport
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Desktop load | Viewport ≥768px | Hero at 90vh, fluid headline ~4rem, staggered animation plays | N/A |
+| Mobile load | Viewport <768px | Hero at 80vh, headline clamps to ~2.5rem, same animation | N/A |
+| Reduced motion | `prefers-reduced-motion: reduce` | All content visible instantly, no animation | N/A |
+| Narrow viewport | ~320px width | Content wraps naturally, no overflow, scroll hint visible | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `src/components/HeroChapter.astro` -- New component: hero markup + scoped animation keyframes
+- `src/pages/index.astro` -- Import and render HeroChapter, replace placeholder content
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `src/components/HeroChapter.astro` -- Create component with headline, subtitle, scroll hint, and scoped CSS animation keyframes with staggered delays (0s, 0.3s, 0.8s). Use `<style>` block for keyframes and `prefers-reduced-motion` media query.
+- [x] `src/pages/index.astro` -- Replace `<h1>Home</h1>` with `<HeroChapter />`. Keep BaseLayout wrapper with `transparent={true}`.
+
+**Acceptance Criteria:**
+- Given the homepage loads, when the HeroChapter renders, then it occupies min-height 90vh (80vh on mobile) with centered content
+- Given the headline, when rendered, then key phrase displays in amber (`text-accent`) and uses Sora Bold at fluid size (`font-size-hero` token)
+- Given motion is allowed, when the page loads, then headline fades up over 0.8s, subtitle follows at 0.3s delay, scroll hint at 0.8s delay
+- Given `prefers-reduced-motion: reduce`, when the page loads, then all content is immediately visible with no animation
+- Given the scroll hint, when rendered, then it displays in monospace (`font-code`) at the bottom of the hero
+
+## Design Notes
+
+**Headline copy** (from UX spec): *"Help your team create more value, solve harder problems, and use AI to its full potential."* — amber emphasis on a key phrase (e.g., "use AI to its full potential").
+
+**Subtitle copy** (from UX spec): Positions Mike as the experienced guide. E.g., *"I'm Mike Hentges — 20+ years building technology organizations, now helping leaders navigate what AI actually changes."*
+
+**Scroll hint:** Small monospace text like "Scroll to explore ↓" anchored near the bottom of the hero viewport.
+
+**Animation approach:** CSS `@keyframes fadeUp` on a scoped `<style>` block. Each element gets `animation-delay` for staggering. Elements start with `opacity: 0; transform: translateY(1rem)` and animate to final position. The `prefers-reduced-motion` query sets `animation: none` and resets opacity/transform to visible defaults.
+
+## Verification
+
+**Commands:**
+- `pnpm build` -- expected: build succeeds with no errors or warnings
+- `npx astro check` -- expected: no type errors
+
+**Manual checks:**
+- Homepage renders hero at full viewport height with correct typography and amber accent
+- Animation staggers correctly on page load (headline → subtitle → scroll hint)
+- With reduced motion preference, all content appears instantly
+- No horizontal scroll on mobile viewports (320px+)
+
+## Suggested Review Order
+
+- Entry point: full-viewport hero with semantic landmark, fluid type, and staggered animation classes
+  [`HeroChapter.astro:4`](../../src/components/HeroChapter.astro#L4)
+
+- CSS-only animation: explicit from/to keyframes, delay classes, and reduced-motion reset
+  [`HeroChapter.astro:19`](../../src/components/HeroChapter.astro#L19)
+
+- Homepage integration: HeroChapter replaces placeholder, transparent nav preserved
+  [`index.astro:1`](../../src/pages/index.astro#L1)

--- a/_bmad-output/implementation-artifacts/spec-2-2-chapterlabel-and-povsection-components.md
+++ b/_bmad-output/implementation-artifacts/spec-2-2-chapterlabel-and-povsection-components.md
@@ -1,0 +1,83 @@
+---
+title: 'ChapterLabel & POVSection Components'
+type: 'feature'
+created: '2026-04-05'
+status: 'done'
+baseline_commit: 'bd24834'
+context:
+  - '_bmad-output/planning-artifacts/ux-design-specification.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** The homepage currently ends after the hero. The narrative scroll flow needs its next beat — a point-of-view statement that tells visitors "this person understands my world" — preceded by a reusable chapter label pattern used across all homepage sections.
+
+**Approach:** Create a `ChapterLabel` component (small monospace amber label) and a `POVSection` component (full-width surface-background section with blockquote), then wire both into the homepage below the hero.
+
+## Boundaries & Constraints
+
+**Always:**
+- Use only Tailwind utility classes (no `@apply`)
+- Use only theme tokens (no raw hex values)
+- Semantic HTML: `<blockquote>` for the quote, `<section>` with `aria-labelledby` for POVSection
+- ChapterLabel must be reusable — it will appear above PillarGrid, Recent Writing, and CTA sections in future stories
+- POVSection background must be full-width (break out of the 1200px container) while content stays constrained
+
+**Ask First:**
+- Changes to BaseLayout or the page-width container system
+
+**Never:**
+- JavaScript in these components — pure HTML/CSS
+- New design tokens or font changes
+- Modifications to HeroChapter
+
+</frozen-after-approval>
+
+## Code Map
+
+- `src/components/ChapterLabel.astro` -- New. Reusable small monospace amber label.
+- `src/components/POVSection.astro` -- New. Full-width surface section with chapter label + blockquote.
+- `src/pages/index.astro` -- Add POVSection below HeroChapter.
+- `src/styles/global.css` -- May need a utility for full-width breakout if not already possible with Tailwind.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `src/components/ChapterLabel.astro` -- Create component accepting a `text` prop, rendering monospace amber text at small size with slight opacity
+- [x] `src/components/POVSection.astro` -- Create component with full-width surface background, ChapterLabel ("Point of View"), and blockquote with 2px left amber border in Sora Medium ~2rem. Placeholder copy: "Most teams don't have a technology problem. They have a clarity problem — too many tools, too little alignment, and no one connecting what the business needs to what the systems can do."
+- [x] `src/pages/index.astro` -- Import and add POVSection below HeroChapter
+
+**Acceptance Criteria:**
+- Given the homepage, when scrolling past the hero, then a "Point of View" chapter label appears above a blockquote on a surface-colored background
+- Given the POVSection, when viewed on any viewport width, then the surface background spans full viewport width while blockquote content stays within max-width
+- Given the ChapterLabel component, when rendered with different text values, then it displays consistently in monospace amber with slight opacity
+- Given the blockquote, when rendered, then it uses Sora Medium at ~2rem with a 2px left amber border
+- Given a mobile viewport, when viewing the POVSection, then text sizes reduce appropriately and spacing tightens
+
+## Verification
+
+**Commands:**
+- `pnpm build` -- expected: builds without errors or type warnings
+- `pnpm dev` -- expected: homepage shows hero followed by POV section with correct styling
+
+**Manual checks:**
+- POVSection surface background bleeds to full viewport width on desktop
+- ChapterLabel renders in monospace, amber, with reduced opacity
+- Blockquote has visible 2px left amber border
+- Responsive: section looks correct at mobile, tablet, and desktop widths
+
+## Suggested Review Order
+
+- Homepage wiring — single entry point showing both new components in use
+  [`index.astro:7`](../../src/pages/index.astro#L7)
+
+- Full-width breakout pattern with `100vw` inline style, surface background, constrained inner content
+  [`POVSection.astro:5`](../../src/components/POVSection.astro#L5)
+
+- Reusable chapter label as `<h2>` with monospace amber styling and optional `id` for `aria-labelledby`
+  [`ChapterLabel.astro:10`](../../src/components/ChapterLabel.astro#L10)
+
+- `overflow-x: hidden` on body to prevent horizontal scrollbar from `100vw` pattern
+  [`global.css:37`](../../src/styles/global.css#L37)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -37,7 +37,7 @@
 generated: 2026-04-02
 last_updated: 2026-04-05
 project: mikehentges_astro
-# last_operational_update: 2026-04-05 epic-1 retrospective completed
+# last_operational_update: 2026-04-05 story 2-2 chapterlabel and povsection components done
 project_key: NOKEY
 tracking_system: file-system
 story_location: "{project-root}/_bmad-output/implementation-artifacts"
@@ -54,9 +54,9 @@ development_status:
   epic-1-retrospective: done
 
   # Epic 2: Homepage Experience
-  epic-2: backlog
-  2-1-herochapter-component: backlog
-  2-2-chapterlabel-and-povsection-components: backlog
+  epic-2: in-progress
+  2-1-herochapter-component: done
+  2-2-chapterlabel-and-povsection-components: done
   2-3-pillargrid-section: backlog
   2-4-blogcard-and-recent-writing-section: backlog
   2-5-ctasection-component: backlog

--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+  href: string;
+  date: string;
+  datetime: string;
+  title: string;
+  summary: string;
+}
+
+const { href, date, datetime, title, summary } = Astro.props;
+---
+
+<a href={href} class="group block border border-border bg-background p-6 transition-all duration-300 ease-out hover:-translate-y-[3px] hover:border-accent">
+  <time datetime={datetime} class="font-code text-[length:var(--font-size-small)] font-[number:var(--font-weight-small)] leading-[var(--line-height-small)] text-accent">
+    {date}
+  </time>
+  <h3 class="mt-2 font-display text-lg font-semibold text-text-primary">
+    {title}
+  </h3>
+  <p class="mt-2 text-base leading-relaxed text-text-secondary">
+    {summary}
+  </p>
+</a>

--- a/src/components/CTASection.astro
+++ b/src/components/CTASection.astro
@@ -1,0 +1,14 @@
+---
+---
+
+<section aria-labelledby="cta-heading" class="py-16 text-center md:py-24">
+  <h2 id="cta-heading" class="font-display text-[2rem] font-semibold text-text-primary md:text-[2.5rem]">
+    Let's talk.
+  </h2>
+  <p class="mx-auto mt-4 max-w-[480px] text-text-secondary">
+    I take on a small number of advisory and project engagements.
+  </p>
+  <p class="mt-8">
+    <a href="mailto:mike@hentges.ai" class="link-text text-lg">mike@hentges.ai</a>
+  </p>
+</section>

--- a/src/components/ChapterLabel.astro
+++ b/src/components/ChapterLabel.astro
@@ -1,0 +1,12 @@
+---
+interface Props {
+  text: string;
+  id?: string;
+}
+
+const { text, id } = Astro.props;
+---
+
+<h2 id={id} class="font-code text-[length:var(--font-size-small)] font-[number:var(--font-weight-small)] leading-[var(--line-height-small)] tracking-widest text-accent/70 uppercase">
+  {text}
+</h2>

--- a/src/components/HeroChapter.astro
+++ b/src/components/HeroChapter.astro
@@ -1,0 +1,51 @@
+---
+---
+
+<section aria-labelledby="hero-heading" class="flex min-h-[80vh] flex-col items-center justify-center px-6 text-center md:min-h-[90vh]">
+  <h1 id="hero-heading" class="hero-animate font-display text-[length:var(--font-size-hero)] font-[number:var(--font-weight-hero)] leading-[var(--line-height-hero)]">
+    Help your team create more value, solve harder problems, and <span class="text-accent">use AI to its full potential</span>.
+  </h1>
+
+  <p class="hero-animate hero-delay-1 mt-6 max-w-[680px] text-text-secondary md:mt-8 md:text-lg">
+    I'm Mike Hentges — 20+ years building technology organizations, now helping leaders navigate what AI actually changes.
+  </p>
+
+  <p class="hero-animate hero-delay-2 mt-auto pb-8 font-code text-[length:var(--font-size-small)] font-[number:var(--font-weight-small)] leading-[var(--line-height-small)] text-text-secondary">
+    Scroll to explore <span aria-hidden="true">↓</span>
+  </p>
+</section>
+
+<style>
+  .hero-animate {
+    opacity: 0;
+    transform: translateY(1rem);
+    animation: fadeUp 0.8s ease forwards;
+  }
+
+  .hero-delay-1 {
+    animation-delay: 0.3s;
+  }
+
+  .hero-delay-2 {
+    animation-delay: 0.8s;
+  }
+
+  @keyframes fadeUp {
+    from {
+      opacity: 0;
+      transform: translateY(1rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero-animate {
+      animation: none;
+      opacity: 1;
+      transform: none;
+    }
+  }
+</style>

--- a/src/components/POVSection.astro
+++ b/src/components/POVSection.astro
@@ -1,0 +1,12 @@
+---
+import ChapterLabel from './ChapterLabel.astro';
+---
+
+<section aria-labelledby="pov-heading" class="relative bg-surface py-16 md:py-24" style="width: 100vw; margin-left: calc(50% - 50vw);">
+  <div class="mx-auto max-w-[1200px] px-6 md:px-8">
+    <ChapterLabel text="Point of View" id="pov-heading" />
+    <blockquote class="mt-6 border-l-2 border-accent pl-6 font-display text-[1.75rem] font-medium leading-snug md:pl-8 md:text-[2rem]">
+      Most teams don't have a technology problem. They have a clarity problem&nbsp;&mdash; too many tools, too little alignment, and no one connecting what the business needs to what the systems can do.
+    </blockquote>
+  </div>
+</section>

--- a/src/components/PillarGrid.astro
+++ b/src/components/PillarGrid.astro
@@ -1,0 +1,33 @@
+---
+import ChapterLabel from './ChapterLabel.astro';
+---
+
+<section aria-labelledby="pillars-heading" class="py-16 md:py-24">
+  <ChapterLabel text="What I Bring" id="pillars-heading" />
+  <div class="mt-8 grid grid-cols-1 gap-px bg-border md:grid-cols-3">
+    <div class="bg-background p-6 md:p-8">
+      <h3 class="font-display text-lg font-semibold text-text-primary">
+        Builder Who Reads Systems
+      </h3>
+      <p class="mt-3 text-base leading-relaxed text-text-secondary">
+        I've spent two decades inside complex technology organizations — not advising from the outside, but building, shipping, and learning what actually works at scale.
+      </p>
+    </div>
+    <div class="bg-background p-6 md:p-8">
+      <h3 class="font-display text-lg font-semibold text-text-primary">
+        Problem Translator
+      </h3>
+      <p class="mt-3 text-base leading-relaxed text-text-secondary">
+        The gap between what the business needs and what the systems can do is where most initiatives stall. I close that gap — turning ambiguity into architecture and strategy into shipping code.
+      </p>
+    </div>
+    <div class="bg-background p-6 md:p-8">
+      <h3 class="font-display text-lg font-semibold text-text-primary">
+        Production, Not Prototypes
+      </h3>
+      <p class="mt-3 text-base leading-relaxed text-text-secondary">
+        Demos are easy. Production is where value lives. I focus on solutions that survive contact with real users, real data, and real organizational constraints.
+      </p>
+    </div>
+  </div>
+</section>

--- a/src/components/RecentWriting.astro
+++ b/src/components/RecentWriting.astro
@@ -1,0 +1,42 @@
+---
+import ChapterLabel from './ChapterLabel.astro';
+import BlogCard from './BlogCard.astro';
+
+interface Post {
+  href: string;
+  date: string;
+  datetime: string;
+  title: string;
+  summary: string;
+}
+
+interface Props {
+  posts?: Post[];
+}
+
+const { posts = [] } = Astro.props;
+const displayPosts = posts.slice(0, 3);
+const hasMore = posts.length > 3;
+---
+
+{displayPosts.length > 0 && (
+  <section aria-labelledby="writing-heading" class="py-16 md:py-24">
+    <ChapterLabel text="Recent Writing" id="writing-heading" />
+    <div class="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {displayPosts.map((post) => (
+        <BlogCard
+          href={post.href}
+          date={post.date}
+          datetime={post.datetime}
+          title={post.title}
+          summary={post.summary}
+        />
+      ))}
+    </div>
+    {hasMore && (
+      <div class="mt-8 text-center">
+        <a href="/blog" class="link-text">View all posts</a>
+      </div>
+    )}
+  </section>
+)}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,7 +12,8 @@ const { title = 'Hentges.AI', transparent = false } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" class="no-js">
+<script is:inline>document.documentElement.classList.remove('no-js');</script>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,8 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import HeroChapter from '../components/HeroChapter.astro';
 ---
 
 <BaseLayout title="Home | Hentges.AI" transparent={true}>
-  <h1>Home</h1>
+  <HeroChapter />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,10 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import HeroChapter from '../components/HeroChapter.astro';
+import POVSection from '../components/POVSection.astro';
 ---
 
 <BaseLayout title="Home | Hentges.AI" transparent={true}>
   <HeroChapter />
+  <POVSection />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,9 +2,75 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import HeroChapter from '../components/HeroChapter.astro';
 import POVSection from '../components/POVSection.astro';
+import PillarGrid from '../components/PillarGrid.astro';
+import RecentWriting from '../components/RecentWriting.astro';
+import CTASection from '../components/CTASection.astro';
 ---
 
 <BaseLayout title="Home | Hentges.AI" transparent={true}>
   <HeroChapter />
-  <POVSection />
+  <div class="scroll-reveal">
+    <POVSection />
+  </div>
+  <div class="scroll-reveal">
+    <PillarGrid />
+  </div>
+  <!-- RecentWriting self-hides when no posts exist; scroll-reveal added when content collection is wired -->
+  <RecentWriting />
+  <div class="scroll-reveal">
+    <CTASection />
+  </div>
 </BaseLayout>
+
+<style>
+  .scroll-reveal {
+    opacity: 0;
+    transform: translateY(1.5rem);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+  }
+
+  .scroll-reveal.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  /* Progressive enhancement: show content if JS is unavailable */
+  :global(.no-js) .scroll-reveal {
+    opacity: 1;
+    transform: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .scroll-reveal {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (!prefersReducedMotion) {
+    const reveals = document.querySelectorAll('.scroll-reveal');
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1 }
+    );
+
+    reveals.forEach((el) => observer.observe(el));
+  } else {
+    document.querySelectorAll('.scroll-reveal').forEach((el) => {
+      el.classList.add('is-visible');
+    });
+  }
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,6 +34,7 @@ body {
   line-height: 1.7;
   background-color: var(--color-background);
   color: var(--color-text-primary);
+  overflow-x: hidden;
 }
 
 h1 {


### PR DESCRIPTION
## Summary

- **PillarGrid** — 3-column CSS grid (1-col mobile) with gap-based borders displaying value pillars: Builder Who Reads Systems, Problem Translator, Production Not Prototypes
- **BlogCard & RecentWriting** — Card component with hover lift + amber border, section self-hides when no posts exist (content collection comes in Epic 3)
- **CTASection** — "Let's talk." closing section with email link, reusable for About page
- **Scroll animations** — IntersectionObserver fade-up reveals with progressive enhancement (`no-js` class fallback) and `prefers-reduced-motion` support
- **BaseLayout** — Added `no-js` class on `<html>` removed by inline script for progressive enhancement

## Test plan

- [ ] `pnpm build` passes with 0 errors/warnings
- [ ] Homepage renders all sections in order: Hero → POV → Pillars → CTA
- [ ] PillarGrid shows 3 columns on desktop, stacks on mobile
- [ ] Scroll animations fire as sections enter viewport
- [ ] No animations with `prefers-reduced-motion: reduce` enabled
- [ ] All content visible with JavaScript disabled
- [ ] No horizontal scrollbar on any viewport width
- [ ] BlogCard hover state: amber border + translateY(-3px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)