### PR TITLE
feat: About & Contact pages (Epic 4)

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -32,3 +32,7 @@
 ## Deferred from: code review of 3-2-blog-post-page-with-authorbio (2026-04-05)
 
 - Hero image alt text is generic (`Hero image for {title}`). Consider adding a `heroAlt` field to the content schema for meaningful image descriptions per WCAG best practices.
+
+## Deferred from: code review of 4-1-about-page (2026-04-05)
+
+- No `<meta name="description">` or Open Graph tags on the About page — BaseLayout currently has no SEO metadata props. Will be addressed in Epic 5 (Story 5-1: SEOHead component).

--- a/_bmad-output/implementation-artifacts/epic-4-completion-report.md
+++ b/_bmad-output/implementation-artifacts/epic-4-completion-report.md
@@ -1,0 +1,41 @@
+# Epic 4 Completion Report — About & Contact Pages
+
+**Branch:** feature/epic-4-about-and-contact-pages
+**Date:** 2026-04-05
+**Status:** Complete
+
+## Stories Completed
+
+| Story | Title | Summary |
+|-------|-------|---------|
+| 4-1-about-page | About Page | Career narrative weaving three professional threads (enterprise systems builder, manufacturing operations leader, AI practitioner) with editorial tone. Reuses CTASection at bottom. Semantic HTML with aria-labelledby, prose-width constraint, proper heading hierarchy. |
+| 4-2-contact-page | Contact Page | Intentionally minimal contact page with mailto:mike@hentges.ai and LinkedIn link. Framing text sets expectations. No contact form — simplicity is the trust signal. Satisfies FR11 (LinkedIn CTA on contact page). |
+
+## Stories Skipped
+
+_(None — all stories completed)_
+
+## Build Result
+
+**Status:** PASS
+**Build time:** 924ms
+**Pages:** 10
+**Warnings:** 5 hints (pre-existing Zod deprecation notices in content.config.ts — not introduced by this epic)
+
+## Code Review Summary
+
+**Story 4-1:** 1 patch applied (added aria-labelledby on article element), 1 deferred (SEO meta tags — Epic 5), 6 dismissed
+**Story 4-2:** 0 patches, 0 deferred (SEO meta already logged), 5 dismissed. All ACs passed clean.
+
+## Deferred Items
+
+- No `<meta name="description">` or Open Graph tags on About and Contact pages — BaseLayout has no SEO metadata props. Will be addressed in Epic 5 (Story 5-1: SEOHead component).
+
+## Next Steps
+
+To push this branch and create a PR:
+
+```bash
+git push -u origin feature/epic-4-about-and-contact-pages
+gh pr create --title "feat: About & Contact pages (Epic 4)" --body "Epic 4 implementation — see epic-4-completion-report.md for details"
+```

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -72,9 +72,9 @@ development_status:
   epic-3-retrospective: optional
 
   # Epic 4: About & Contact Pages
-  epic-4: backlog
-  4-1-about-page: backlog
-  4-2-contact-page: backlog
+  epic-4: done
+  4-1-about-page: done
+  4-2-contact-page: done
   epic-4-retrospective: optional
 
   # Epic 5: SEO & Launch Readiness

--- a/_bmad-output/implementation-artifacts/story-4-1-about-page.md
+++ b/_bmad-output/implementation-artifacts/story-4-1-about-page.md
@@ -1,0 +1,142 @@
+# Story 4.1: About Page
+
+Status: done
+
+## Story
+
+As a prospect evaluating Mike's credibility,
+I want to read about his career depth across enterprise, manufacturing, and AI,
+so that I can confirm he has the experience to advise on my situation.
+
+## Acceptance Criteria
+
+1. **Given** the About page at `/about`, **when** it renders, **then** it presents a career narrative weaving three professional threads: enterprise systems builder (20+ years CTO at Fortune 500 SI), manufacturing operations leader (3 years IT Director), and AI practitioner. The narrative reinforces brand pillars without reading like a resume. The page has a proper heading (h1) and follows the 680px prose max-width.
+
+2. **Given** the About page content, **when** the visitor reaches the bottom, **then** a CTASection (reused from Epic 2) appears with heading, subtitle, and email link. The CTA provides a natural transition from "who is this person" to "how do I reach them."
+
+3. **Given** the About page, **when** examined for accessibility, **then** it uses semantic HTML with proper heading hierarchy (h1 -> h2, never skip levels) and renders responsively across all breakpoints.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Write About page content and structure (AC: 1, 3)
+  - [x] 1.1 Replace placeholder in `src/pages/about.astro` with full page implementation
+  - [x] 1.2 Write career narrative content weaving three threads: enterprise systems builder, manufacturing operations leader, AI practitioner
+  - [x] 1.3 Structure content with semantic HTML: `<article>` wrapper, proper heading hierarchy (h1 -> h2 for each thread/section)
+  - [x] 1.4 Apply `prose-width` class to article for 680px max content width
+  - [x] 1.5 Use `prose prose-lg` wrapper for narrative body text (matches blog post pattern)
+  - [x] 1.6 Ensure narrative tone is editorial — "who this person is" not "resume bullet points"
+
+- [x] Task 2: Integrate CTASection component (AC: 2)
+  - [x] 2.1 Import and render `CTASection` component at the bottom of the page, below the narrative content
+  - [x] 2.2 Verify CTA appears as natural closing: "Let's talk." heading + subtitle + email link
+
+- [x] Task 3: Responsive and accessibility verification (AC: 3)
+  - [x] 3.1 Verify heading hierarchy: h1 (page title) -> h2 (section headings) — no skipped levels
+  - [x] 3.2 Test responsive layout: mobile (single column, tighter spacing), tablet, desktop
+  - [x] 3.3 Verify `aria-current="page"` is set on the "About" nav link in StickyNav (already handled by StickyNav component)
+  - [x] 3.4 Run `pnpm build` — zero errors, page renders at `/about`
+
+## Dev Notes
+
+### Page Structure Pattern
+
+Follow the established content page pattern from blog post pages:
+
+```astro
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import CTASection from '../components/CTASection.astro';
+---
+
+<BaseLayout title="About | Hentges.AI">
+  <article class="prose-width py-12 md:py-16">
+    <h1 class="font-display text-4xl font-bold leading-tight md:text-[2.5rem]">
+      <!-- Page title -->
+    </h1>
+    <div class="prose prose-lg mt-8 max-w-none">
+      <!-- Career narrative content as raw HTML sections -->
+    </div>
+  </article>
+  <CTASection />
+</BaseLayout>
+```
+
+### Key Implementation Details
+
+- **No new components needed.** This is a content page using existing layout + CTASection.
+- **CTASection import:** `import CTASection from '../components/CTASection.astro';` — component takes no props, renders identically everywhere.
+- **BaseLayout props:** `title="About | Hentges.AI"` — do NOT pass `transparent={true}` (that's homepage-only).
+- **Prose styling:** Wrap narrative text in `<div class="prose prose-lg mt-8 max-w-none">` — this activates Tailwind Typography with the dark theme overrides already defined in `global.css`.
+- **prose-width class:** Already defined in global.css as `max-width: 680px` — apply to the `<article>` wrapper.
+- **Spacing pattern:** `py-12 md:py-16` on article (matches blog post page).
+- **h1 styling:** `font-display text-4xl font-bold leading-tight md:text-[2.5rem]` (matches blog post h1 pattern).
+
+### Content Guidelines
+
+The three career threads to weave into narrative:
+
+1. **Enterprise Systems Builder** — 20+ years as CTO at a Fortune 500 systems integrator. Large-scale delivery, complex integrations, enterprise architecture.
+2. **Manufacturing Operations Leader** — 3 years as IT Director at a mid-sized manufacturer. Hands-on operational technology, real-world production systems.
+3. **AI Practitioner** — Applied AI expertise. Not theoretical — building real solutions that survive production.
+
+**Tone:** The narrative should feel like the "about" section of a respected Substack author. Conversational but authoritative. Reinforce brand pillars (Builder Who Reads Systems, Problem Translator, Production Not Prototypes) without naming them explicitly. NOT a resume, NOT a LinkedIn profile, NOT a corporate bio.
+
+**Structure suggestion:** A single flowing narrative with 2-3 section breaks (h2 headings) that naturally moves from "who I am" to "what I've learned" to "how I work." Each section weaves the threads together rather than treating them as separate career chapters.
+
+### Anti-Patterns to Avoid
+
+- Do NOT create new components for this page — it's a content page, not a component showcase
+- Do NOT use `@apply` — Tailwind utility classes only
+- Do NOT use raw hex colors — use theme tokens (`text-text-primary`, `text-text-secondary`, `text-accent`)
+- Do NOT use raw `<img>` tags — use Astro `<Image>` component if any images are added
+- Do NOT add `transparent` prop to BaseLayout (homepage-only feature)
+- Do NOT skip heading levels (no h1 -> h3)
+- Do NOT create a separate layout component — use BaseLayout directly
+
+### Existing Components Reference
+
+| Component | Import Path | Usage on About Page |
+|-----------|-------------|-------------------|
+| BaseLayout | `../layouts/BaseLayout.astro` | Page wrapper with nav + footer |
+| CTASection | `../components/CTASection.astro` | Closing CTA at bottom |
+
+### Project Structure Notes
+
+- File to modify: `src/pages/about.astro` (replace existing placeholder)
+- No new files needed
+- Architecture doc confirms: `/about` route uses BaseLayout + CTASection only
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/architecture.md — Route-Component Mapping]: `/about` uses BaseLayout + CTASection
+- [Source: _bmad-output/planning-artifacts/epics.md — Story 4.1]: Full acceptance criteria and user story
+- [Source: _bmad-output/planning-artifacts/prd.md — Scope]: About page with three career threads, narrative style
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md — Design Principles]: "Judgment on display", "Confidence through restraint"
+- [Source: src/pages/blog/[slug].astro]: Content page pattern (article wrapper, prose styling, spacing)
+- [Source: src/components/CTASection.astro]: Reusable CTA — no props, self-contained
+- [Source: src/styles/global.css]: prose-width (680px), prose overrides, link hierarchy classes
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (1M context)
+
+### Debug Log References
+
+None — clean implementation, no debugging required.
+
+### Completion Notes List
+
+- Replaced placeholder about.astro with full career narrative page
+- Three career threads woven into flowing editorial narrative with three h2 sections: "Twenty years inside enterprise delivery", "Then I went to the factory floor", "Now: making AI actually work"
+- Tone matches homepage voice — conversational, authoritative, slightly irreverent. NOT resume-like.
+- Reuses CTASection component at bottom for natural "who is this → how to reach them" transition
+- Article wrapped in `prose-width` (680px) with `prose prose-lg` for Tailwind Typography
+- Heading hierarchy: h1 → h2 (no skipped levels)
+- Build passes: 0 errors, 10 pages built, /about/index.html generated
+- No new components or files created — single file modification as specified
+
+### File List
+
+- `src/pages/about.astro` (modified — replaced placeholder with full implementation)

--- a/_bmad-output/implementation-artifacts/story-4-2-contact-page.md
+++ b/_bmad-output/implementation-artifacts/story-4-2-contact-page.md
@@ -1,0 +1,141 @@
+# Story 4.2: Contact Page
+
+Status: done
+
+## Story
+
+As a convinced prospect,
+I want a simple, direct way to reach out,
+so that contacting Mike feels personal and low-friction, not like entering a sales funnel.
+
+## Acceptance Criteria
+
+1. **Given** the Contact page at `/contact`, **when** it renders, **then** it displays a `mailto:mike@hentges.ai` link styled as a text link with amber underline, a LinkedIn profile link, brief framing text ("I take on a small number of advisory and project engagements each year." or similar), and there is no contact form of any kind.
+
+2. **Given** the Contact page, **when** a visitor clicks the email link, **then** their default email client opens with mike@hentges.ai as the recipient.
+
+3. **Given** the Contact page, **when** examined for design, **then** the simplicity IS the trust signal — the page is intentionally minimal. It renders responsively across all breakpoints.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Build Contact page content and structure (AC: 1, 2, 3)
+  - [x] 1.1 Replace placeholder in `src/pages/contact.astro` with full page implementation
+  - [x] 1.2 Add h1 heading with `aria-labelledby` on wrapping `<article>` (pattern from story 4-1)
+  - [x] 1.3 Add brief framing text — conversational, not salesy
+  - [x] 1.4 Add `mailto:mike@hentges.ai` link using `.link-text` class (amber text + 2px underline)
+  - [x] 1.5 Add LinkedIn profile link (`https://www.linkedin.com/in/mikehentges/`) — satisfies FR11 for contact page
+  - [x] 1.6 Ensure NO contact form exists — simplicity is the design
+
+- [x] Task 2: Responsive and accessibility verification (AC: 3)
+  - [x] 2.1 Verify heading hierarchy: h1 only — no skipped levels
+  - [x] 2.2 Verify responsive layout across breakpoints
+  - [x] 2.3 Verify `aria-current="page"` on Contact nav link (handled by StickyNav)
+  - [x] 2.4 Run `pnpm build` — zero errors, page renders at `/contact`
+
+## Dev Notes
+
+### Page Structure Pattern
+
+Follow the pattern established in story 4-1 (About page):
+
+```astro
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Contact | Hentges.AI">
+  <article aria-labelledby="contact-heading" class="prose-width py-12 md:py-16">
+    <h1 id="contact-heading" class="font-display text-4xl font-bold leading-tight md:text-[2.5rem]">
+      <!-- Heading -->
+    </h1>
+    <!-- Framing text + links -->
+  </article>
+</BaseLayout>
+```
+
+### Key Implementation Details
+
+- **No new components needed.** This is a minimal content page using BaseLayout only.
+- **No CTASection on this page.** The contact page IS the CTA destination — adding CTASection would be circular.
+- **BaseLayout props:** `title="Contact | Hentges.AI"` — do NOT pass `transparent={true}`.
+- **Email link:** Use `.link-text` class for the mailto link (amber text with 2px border-bottom underline). This class is already defined in `global.css`.
+- **LinkedIn link:** Use same `.link-text` styling or inline amber link pattern. Must open in new tab (`target="_blank" rel="noopener noreferrer"`).
+- **prose-width class:** Apply to `<article>` for 680px max content width.
+- **Spacing pattern:** `py-12 md:py-16` on article (consistent with About page).
+- **aria-labelledby:** Add `id` to h1, reference from `<article>` (learned from story 4-1 code review).
+
+### Content Guidelines
+
+**Tone:** The page should feel like a personal invitation, not a corporate contact form. The absence of a form IS the trust signal — it says "I'm a real person, not a funnel."
+
+**Required elements:**
+- Framing text: Something like "I take on a small number of advisory and project engagements each year." — brief, human, sets expectations
+- Email: `mike@hentges.ai` as a clickable mailto link
+- LinkedIn: `https://www.linkedin.com/in/mikehentges/` (satisfies FR11)
+
+**The page should be intentionally sparse.** A few lines of text, two links, done. The restraint IS the design.
+
+### Anti-Patterns to Avoid
+
+- Do NOT create new components — this is a content page
+- Do NOT add a contact form of any kind
+- Do NOT use `@apply` — Tailwind utility classes only
+- Do NOT use raw hex colors — use theme tokens
+- Do NOT add `transparent` prop to BaseLayout
+- Do NOT add CTASection (this page IS the contact destination)
+- Do NOT skip heading levels
+
+### Previous Story Intelligence (4-1-about-page)
+
+- Used `<article aria-labelledby="...">` with `id` on h1 — apply same pattern
+- `prose-width py-12 md:py-16` on article wrapper — reuse
+- h1 styling: `font-display text-4xl font-bold leading-tight md:text-[2.5rem]` — reuse
+- Code review found: always add `aria-labelledby` on `<article>` — already incorporated above
+- Code review deferred: no SEO meta tags — same applies here, addressed in Epic 5
+
+### Existing Components Reference
+
+| Component | Import Path | Usage on Contact Page |
+|-----------|-------------|----------------------|
+| BaseLayout | `../layouts/BaseLayout.astro` | Page wrapper with nav + footer |
+
+### Project Structure Notes
+
+- File to modify: `src/pages/contact.astro` (replace existing placeholder)
+- No new files needed
+- Architecture doc confirms: `/contact` route uses BaseLayout only (no additional components)
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/architecture.md — Route-Component Mapping]: `/contact` uses BaseLayout, no additional components
+- [Source: _bmad-output/planning-artifacts/epics.md — Story 4.2]: Full acceptance criteria
+- [Source: _bmad-output/planning-artifacts/prd.md — Scope]: Contact page with direct email, LinkedIn, no forms
+- [Source: src/pages/about.astro]: Previous story pattern (article wrapper, aria-labelledby, spacing)
+- [Source: src/styles/global.css]: `.link-text` class (amber text + 2px border-bottom underline)
+- [Source: src/components/AuthorBio.astro]: LinkedIn link pattern with `target="_blank" rel="noopener noreferrer"`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (1M context)
+
+### Debug Log References
+
+None — clean implementation.
+
+### Completion Notes List
+
+- Replaced placeholder contact.astro with intentionally minimal contact page
+- h1 "Get in touch." with aria-labelledby on article wrapper
+- Framing text sets expectations: "small number of advisory and project engagements"
+- mailto:mike@hentges.ai with .link-text class (amber + underline)
+- LinkedIn link with target="_blank" rel="noopener noreferrer" — satisfies FR11
+- No contact form — simplicity is the trust signal
+- No CTASection — this page IS the CTA destination
+- Build passes: 0 errors, 10 pages, /contact/index.html generated
+- Applied learnings from 4-1 code review: aria-labelledby on article
+
+### File List
+
+- `src/pages/contact.astro` (modified — replaced placeholder with full implementation)

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,7 +1,57 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import CTASection from '../components/CTASection.astro';
 ---
 
 <BaseLayout title="About | Hentges.AI">
-  <h1>About</h1>
+  <article aria-labelledby="about-heading" class="prose-width py-12 md:py-16">
+    <h1 id="about-heading" class="font-display text-4xl font-bold leading-tight md:text-[2.5rem]">
+      I build things that work in production.
+    </h1>
+
+    <div class="prose prose-lg mt-8 max-w-none">
+      <p>
+        Most of my career has been spent inside the machine — not consulting about it, not theorizing about it, but building technology organizations and making them deliver.
+      </p>
+
+      <h2>Twenty years inside enterprise delivery</h2>
+
+      <p>
+        I spent two decades as CTO of a Fortune 500 systems integrator, leading teams that built and deployed complex contact center solutions for some of the largest companies in the world. The work was integration-heavy, deadline-driven, and unforgiving. You learned to read systems — not just the technology, but the organizations around them. Which stakeholder's requirements were actually requirements. Which architectural decisions would survive the first encounter with production data. Where the real risks hid while everyone argued about the obvious ones.
+      </p>
+
+      <p>
+        That kind of experience doesn't teach you to be clever. It teaches you to be right — or at least to know when you're guessing and plan accordingly.
+      </p>
+
+      <h2>Then I went to the factory floor</h2>
+
+      <p>
+        After twenty years in enterprise services, I took a sharp left turn and became IT Director at a mid-sized manufacturer. Different world. ERP systems, MRP runs, shop floor data, supply chain logistics — none of which I'd touched before. Within three years, I was the company's ERP expert.
+      </p>
+
+      <p>
+        That experience stripped away the last of my consulting instincts. Manufacturing doesn't care about your framework or your methodology. The production line either runs or it doesn't. The inventory numbers are either right or they're wrong. It was a masterclass in what "production-grade" actually means when the stakes are physical, not just financial.
+      </p>
+
+      <h2>Now: making AI actually work</h2>
+
+      <p>
+        Today I advise technology leaders on the question that keeps surfacing in every boardroom and every engineering standup: <em>what does AI actually change for us?</em>
+      </p>
+
+      <p>
+        My answer isn't what most people expect. AI doesn't replace the need for good architecture, clear requirements, or experienced judgment. It amplifies all of those things. The teams that get the most from AI are the ones that already know how to build — they just move faster now, see patterns sooner, and ship with more confidence.
+      </p>
+
+      <p>
+        The teams that struggle are the ones hoping AI will compensate for problems that were already there: unclear strategy, fragile systems, or a gap between what the business needs and what the technology organization can deliver.
+      </p>
+
+      <p>
+        I help close that gap. Not with a pitch deck, but with the perspective of someone who has spent a career on both sides of it — building the systems <em>and</em> running the operations they support.
+      </p>
+    </div>
+  </article>
+  <CTASection />
 </BaseLayout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,5 +3,22 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Contact | Hentges.AI">
-  <h1>Contact</h1>
+  <article aria-labelledby="contact-heading" class="prose-width py-12 md:py-16">
+    <h1 id="contact-heading" class="font-display text-4xl font-bold leading-tight md:text-[2.5rem]">
+      Get in touch.
+    </h1>
+
+    <p class="mt-6 text-lg leading-relaxed text-text-secondary">
+      I take on a small number of advisory and project engagements each year. If you're working through a technology or AI challenge and want a practitioner's perspective, I'd like to hear about it.
+    </p>
+
+    <div class="mt-10 flex flex-col gap-4">
+      <p>
+        <a href="mailto:mike@hentges.ai" class="link-text text-lg">mike@hentges.ai</a>
+      </p>
+      <p>
+        <a href="https://www.linkedin.com/in/mikehentges/" class="link-text text-lg" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      </p>
+    </div>
+  </article>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- **About page** (`/about`): Editorial career narrative weaving three professional threads — enterprise systems builder, manufacturing operations leader, AI practitioner. CTASection reused at bottom.
- **Contact page** (`/contact`): Intentionally minimal — framing text, mailto link, LinkedIn link. No form. Simplicity as trust signal.
- Both pages follow established patterns: `prose-width`, `aria-labelledby`, proper heading hierarchy, responsive layout.

## Test plan
- [ ] Verify `/about` renders career narrative with three h2 sections and CTASection at bottom
- [ ] Verify `/contact` renders email link, LinkedIn link, and framing text with no form
- [ ] Verify `aria-current="page"` highlights correct nav link on each page
- [ ] Verify `pnpm build` passes with zero errors
- [ ] Verify responsive layout on mobile, tablet, and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)